### PR TITLE
Add option to pass json string rather than file descriptor to Tfstate()

### DIFF
--- a/src/tfstate/base/tfstate.py
+++ b/src/tfstate/base/tfstate.py
@@ -17,13 +17,18 @@ class Tfstate(object):
         Tfstate(file_descriptor)
     """
 
-    def __init__(self, file_descriptor):
+    def __init__(self, file_descriptor_or_json_string):
         """
-        :param file file_descriptor: tfstate file descriptor
+        :param file file_descriptor_or_json_string: tfstate file descriptor or json string
         """
 
-        self.tfstate_file = file_descriptor
-        self.load_tfstate_data_from_file()
+        if type(file_descriptor_or_json_string) == str:
+            self.native_data = json.loads(file_descriptor_or_json_string)
+
+        else:
+            self.tfstate_file = file_descriptor_or_json_string
+            self.load_tfstate_data_from_file()
+
         self.version = self.native_data.get('version', None)
         self.serial = self.native_data.get('serial', None)
         self.terraform_version = self.native_data.get('terraform_version', None)
@@ -39,3 +44,4 @@ class Tfstate(object):
         if isinstance(tfstate_data, bytes):
             tfstate_data = tfstate_data.decode('utf-8')
         self.native_data = json.loads(tfstate_data)
+        self.tfstate_file.close()


### PR DESCRIPTION
Thanks for your great project.

Please consider adding the option to pass the JSON state as a string. I am getting my state from a remote backend and don't want to write to a temp file, or hack by importing Module()

If you would consider merging this, I would consider writing tests for it. 😀